### PR TITLE
Add version number

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,6 @@
 {
   "name": "untitled-element",
+  "version": "0.0.0",
   "private": true,
   "dependencies": {
     "polymer": "Polymer/polymer#master"


### PR DESCRIPTION
Adds a default basic version number so users can leverage the `bower version` command.
