### PR TITLE
Bumped Polymer version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "**/.*"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~0.3.4",
-    "polymer-test-tools": "Polymer/polymer-test-tools#~0.3.3"
+    "polymer": "Polymer/polymer#>=0.4.0 <1.0.0",
+    "polymer-test-tools": "Polymer/polymer-test-tools#>=0.4.0 <1.0.0"
   }
 }


### PR DESCRIPTION
When running `bower install`, there is a version conflict:

```
Unable to find a suitable version for polymer, please choose one:
    1) polymer#~0.3.4 which resolved to 0.3.5 and is required by seed-element 
    2) polymer#>=0.4.0 <1.0.0 which resolved to 0.4.0 and is required by core-component-page#0.4.0
```

If I choose the `0.3.5` version, I get an error when running the demo:

``` js
Uncaught TypeError: undefined is not a function
var declarations = Platform.deliverDeclarations();
```

Bumping Polymer version to `0.4.0` fixes the issues.
