### PR TITLE
Add unsolved to body

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <link rel="import" href="../iron-component-page/iron-component-page.html">
 
 </head>
-<body>
+<body unresolved>
   <!-- Note: if the main element for this repository doesn't
        match the folder name, add a src="&lt;main-component&gt;.html" attribute,
        where &lt;main-component&gt;.html" is a file that imports all of the


### PR DESCRIPTION
In polymer elements demo page, almost every demo has noticeable FOUC problem, especially paper elements. Add unresolved to body to solve FOUC issue. 