### PR TITLE
wrap author.img in a div to make it block

### DIFF
--- a/seed-element.html
+++ b/seed-element.html
@@ -30,6 +30,7 @@ Example:
     }
 
     .author img {
+      display: block;
       float: left;
       margin-right: 5px;
       max-height: 100px;
@@ -41,7 +42,7 @@ Example:
     <h1>&lt;seed-element&gt;</h1>
     <content></content>
     <p class="author">
-      <div><img src="{{author.image}}"></div>
+      <img src="{{author.image}}">
       Cheers,<br/>
       <span class="name">{{author.name}}</span>
     </p>

--- a/seed-element.html
+++ b/seed-element.html
@@ -41,7 +41,7 @@ Example:
     <h1>&lt;seed-element&gt;</h1>
     <content></content>
     <p class="author">
-      <img src="{{author.image}}">
+      <div><img src="{{author.image}}"></div>
       Cheers,<br/>
       <span class="name">{{author.name}}</span>
     </p>


### PR DESCRIPTION
wrap author.image in a div to make it block style. The demo portion does a placekitten of 200x300, but since it's inlined, the spec'd res isn't shown, which may confuse some developers. Additionally, it leads to the pic bleeding down below the border of the element (which is easily seen either with devtools or by doing :host{ background-color: yellow; } in the seed-element CSS.
So I'm proposing moving to block style by wrapping it in a div. Other option would be to make it block style via explict CSS but then you'd need another class added in.
