### PR TITLE
Moving style tags to inside of template

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "/test/"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#^1.0.0"
+    "polymer": "Polymer/polymer#^1.1.0"
   },
   "devDependencies": {
     "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",

--- a/seed-element.html
+++ b/seed-element.html
@@ -23,22 +23,21 @@ Example:
 -->
 <dom-module id="seed-element">
 
-  <style>
-    :host {
-      display: block;
-      box-sizing: border-box;
-    }
-
-    .author img {
-      display: block;
-      float: left;
-      margin-right: 5px;
-      max-height: 100px;
-      max-width: 100px;
-    }
-  </style>
-
   <template>
+    <style>
+      :host {
+        display: block;
+        box-sizing: border-box;
+      }
+  
+      .author img {
+        display: block;
+        float: left;
+        margin-right: 5px;
+        max-height: 100px;
+        max-width: 100px;
+      }
+    </style>
     <h1>&lt;seed-element&gt;</h1>
     <content></content>
     <p class="author">


### PR DESCRIPTION
Perf recommendation from v1.1

*Previously, we recommended that a `<style>` element should be placed inside an element’s `<dom-module>` but outside of its template. This is still supported, but we’ve now optimized placing styles within the template itself, so having the `<style>` tag outside of the template will be slower. We will be updating all of the elements provided by the Polymer team to match this new recommended behavior as well.*

https://blog.polymer-project.org/announcements/2015/08/13/1.1-release/