### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 bower_components
+tmp-*


### PR DESCRIPTION
`yo polymer:gh` is generating a `tmp-*` at every publish launched and is not deleted at the end of the process.